### PR TITLE
Fix issue with routing

### DIFF
--- a/Frontend/src/js/App.js
+++ b/Frontend/src/js/App.js
@@ -9,7 +9,7 @@ import ConnectionIcon from '../../../img/svg/icons/icon_connections_sidebar.svg'
 import RemoteFlashingIcon from '../../../img/svg/icons/icon_remote_flashing_sidebar.svg';
 import theme from './styles/theme';
   import {
-	BrowserRouter as Router,
+    HashRouter as Router,
 	Routes,
 	Route,
 	Link


### PR DESCRIPTION
issue: Routing working on Mac but not Windows 

Changed the React Browser router to hash router, which is file based compared to request-based.

I will need someone on a windows device to test whether this works now or if the issue remains